### PR TITLE
Ignore warnings in C parser

### DIFF
--- a/lib/PreProcessor.php
+++ b/lib/PreProcessor.php
@@ -105,6 +105,9 @@ class PreProcessor {
                     case 'endif':
                         // ignore
                         break;
+                    case 'warning':
+                        // ignore
+                        break;
                     case 'error':
                         var_dump($this->context);
                         $this->debug($directive);


### PR DESCRIPTION
They are only warnings, and we do not want invalid tokens.