### PR TITLE
Generic preprocessor improvements

### DIFF
--- a/lib/Context.php
+++ b/lib/Context.php
@@ -427,6 +427,8 @@ result:
                     throw new \LogicException("Base mismatch for {$str}, found $chr for $idx");
                 }
                 $result = ($result * $base) + $chr;
+            } elseif ($str[$idx] === 'U') {
+                // unsigned number, let's not touch it
             } elseif ($str[$idx] === 'L') {
                 // indicates number is a long, return as is
                 if ($idx + 1 !== $length) {

--- a/lib/Context.php
+++ b/lib/Context.php
@@ -44,6 +44,38 @@ class Context {
         }
     }
 
+    public function findHeaderFile(string $header, string $contextDir, string $contextFile, bool $next): ?string {
+        if ($header[0] === '/' || ($header[1] === ':' && $header[2] === '\\')) {
+            if (file_exists($header)) {
+                return $header;
+            }
+        } else {
+            if ($contextDir && !$next) {
+                $dir = $contextDir;
+                while (!empty($dir) && $dir !== '/') {
+                    $file = "$dir/$header";
+                    if (file_exists($file)) {
+                        return $file;
+                    }
+                    $dir = dirname($dir);
+                }
+            }
+            foreach ($this->headerSearchPaths as $path) {
+                if ($next) {
+                    if ($contextDir === $path) {
+                        $next = false;
+                    }
+                    break;
+                }
+                $test = $path . '/' . $header;
+                if (file_exists($test)) {
+                    return $test;
+                }
+            }
+        }
+        return null;
+    }
+
     public function getDefines(): array {
         return $this->definitions;
     }
@@ -142,7 +174,7 @@ class Context {
                     return new Token(Token::NUMBER, '0', 'computed');
             }
             return $expr;
-        } 
+        }
         list ($result, $expr) = $this->evaluateInternal($expr);
         if ($expr !== null) {
             throw new \LogicException('Syntax error: unknown trailing expr: ' . $expr->value);
@@ -187,6 +219,38 @@ restart:
             } else {
                 throw new \LogicException("Syntax Error for #defined expression, expecting ( or IDENTIFIER, found " . $expr->value);
             }
+        } elseif ($expr->type === Token::IDENTIFIER && $expr->value === '__has_include') {
+            $expr = Token::skipWhitespace($expr->next);
+            if ($expr === null) {
+                throw new \LogicException("Syntax Error for __has_include() expression: not enough tokens");
+            }
+            if ($expr->type === Token::PUNCTUATOR && $expr->value === '(') {
+                $expr = Token::skipWhitespace($expr->next);
+                if ($expr->type === Token::LITERAL) {
+                    $file = $expr->value;
+                } elseif ($expr->type === Token::PUNCTUATOR && $expr->value === '<') {
+                    // handle <> include:
+                    $file = '';
+                    while (!empty($expr->next)) {
+                        $expr = $expr->next;
+                        if ($expr->type === Token::PUNCTUATOR && $expr->value === '>') {
+                            break;
+                        }
+                        $file .= $expr->value;
+                    }
+                } else {
+                    throw new \LogicException("Syntax Error for __has_include() expression, expecting < or LITERAL, found " . $expr->value);
+                }
+                $expr = Token::skipWhitespace($expr->next);
+                if ($expr === null || $expr->type !== Token::PUNCTUATOR && $expr->value !== ')') {
+                    throw new \LogicException("Syntax Error for __has_include() expression: ) not found");
+                }
+                $contextDir = dirname($expr->file);
+                $result = new Token(Token::NUMBER, $this->findHeaderFile($file, $contextDir, $expr->file, false) !== null ? '1' : '0', 'computed');
+                $expr = Token::skipWhitespace($expr->next);
+            } else {
+                throw new \LogicException("Syntax Error for #__has_include expression, expecting (, found " . $expr->value);
+            }
         } elseif ($expr->type === Token::IDENTIFIER) {
             $next = Token::skipWhitespace($expr->next);
             if ($next !== null && $next->value === '(') {
@@ -221,6 +285,7 @@ restart:
             $result = new Token(Token::NUMBER, $expr->value, 'computed');
             $expr = Token::skipWhitespace($expr->next);
         } else {
+            var_dump($expr);
             throw new \LogicException('Unknown operator ' . $expr->value);
         }
         if ($negate) {

--- a/lib/PreProcessor.php
+++ b/lib/PreProcessor.php
@@ -104,7 +104,7 @@ class PreProcessor {
                         break;
                     case 'else':
                     case 'elif':
-                        $lines = $this->skipIf($lines);
+                        $lines = $this->skipIf($lines, true);
                         break;
                     case 'endif':
                         // ignore

--- a/test/cases/c/elifchain.phpt
+++ b/test/cases/c/elifchain.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Test for #elif chains
+--FILE--
+
+#if 0
+#elif 1
+#elif 0
+#elif 0
+#else
+#error "ERROR"
+#endif
+
+int bar;
+
+--EXPECT--
+int bar;

--- a/test/cases/c/pragma_once.phpt
+++ b/test/cases/c/pragma_once.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Test for #elif chains
+--FILE--
+
+#include "pragma_once.h"
+#include "pragma_once.h"
+
+int TEST;
+
+--EXPECT--
+int bar;

--- a/test/generated/c/elifchainTest.c
+++ b/test/generated/c/elifchainTest.c
@@ -1,0 +1,11 @@
+
+#if 0
+#elif 1
+#elif 0
+#elif 0
+#else
+#error "ERROR"
+#endif
+
+int bar;
+

--- a/test/generated/c/elifchainTest.php
+++ b/test/generated/c/elifchainTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+namespace PHPCParser\Test\c;
+use PHPCParser\CParser;
+use PHPCParser\Printer;
+use PHPCParser\Printer\Dumper;
+use PHPCParser\Printer\C;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Note: this is a generated file, do not edit this!!!
+ */
+class elifchainTest extends TestCase {
+
+    const EXPECTED = 'int bar;';
+
+    protected CParser $parser;
+    protected Printer $printer;
+
+    public function setUp(): void {
+        $this->parser = new CParser;
+        $this->parser->addSearchPath(__DIR__);
+        $this->parser->addSearchPath(__DIR__ . '/../../include');
+        $this->printer = new C;
+    }
+
+    /**
+     * @textdox Test for #elif chains
+     */
+    public function testCode() {
+        $translationUnit = $this->parser->parse(__DIR__ . '/elifchainTest.c');
+        $actual = $this->printer->print($translationUnit);
+        $this->assertEquals(self::EXPECTED, trim($actual));
+    }
+}

--- a/test/generated/c/pragma_onceTest.c
+++ b/test/generated/c/pragma_onceTest.c
@@ -1,0 +1,6 @@
+
+#include "pragma_once.h"
+#include "pragma_once.h"
+
+int TEST;
+

--- a/test/generated/c/pragma_onceTest.php
+++ b/test/generated/c/pragma_onceTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+namespace PHPCParser\Test\c;
+use PHPCParser\CParser;
+use PHPCParser\Printer;
+use PHPCParser\Printer\Dumper;
+use PHPCParser\Printer\C;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Note: this is a generated file, do not edit this!!!
+ */
+class pragma_onceTest extends TestCase {
+
+    const EXPECTED = 'int bar;';
+
+    protected CParser $parser;
+    protected Printer $printer;
+
+    public function setUp(): void {
+        $this->parser = new CParser;
+        $this->parser->addSearchPath(__DIR__);
+        $this->parser->addSearchPath(__DIR__ . '/../../include');
+        $this->printer = new C;
+    }
+
+    /**
+     * @textdox Test for #elif chains
+     */
+    public function testCode() {
+        $translationUnit = $this->parser->parse(__DIR__ . '/pragma_onceTest.c');
+        $actual = $this->printer->print($translationUnit);
+        $this->assertEquals(self::EXPECTED, trim($actual));
+    }
+}

--- a/test/include/pragma_once.h
+++ b/test/include/pragma_once.h
@@ -1,0 +1,8 @@
+
+#ifdef TEST
+#error "VERY BAD"
+#endif
+
+#pragma once
+
+#define TEST "bar"


### PR DESCRIPTION
Adds support for:

- #include_next
- immediate #elif chaining
- variadic macros / \_\_VA_ARGS__
- #pragma once
- &lt;number>U

I haven't touched #8, i.e. pragma GCC error/warning. Not sure about that one. But do we need it? Isn't it enough to just have the normal #error one?